### PR TITLE
change polymer dependency to 0.5.6 or higher

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "**/.*"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#master",
+    "polymer": "Polymer/polymer#0.5.6",
     "momentjs": "~2.6.0"
   }
 }


### PR DESCRIPTION
This fixes an issue with bower resolving to higher versions of polymer when it isn't necessary to use master branch for the dependency.
